### PR TITLE
Restart test (black-box) and fix restart bug

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -10,6 +10,7 @@
     , "it"
     , "beforeEach"
     , "afterEach"
+    , "__dirname"
   ]
   , "white": true
   , "indent": 2

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ module.exports = function (options) {
         metaWorker.logger.warn('Worker disconnection was unexpected')
 
         metaWorker.state = 'disconnected'
-        newWorker()
+        newWorker(callback)
       }
 
       metaWorker.state = 'disconnected'

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "test": "node_modules/.bin/jshint --exclude=node_modules ."
+    "test": "node_modules/.bin/jshint --exclude=node_modules . && ./node_modules/.bin/mocha --compilers js:test/support/6to5 test"
   },
   "repository": {
     "type": "git",
@@ -19,6 +19,17 @@
     "lodash": "^2.4.1"
   },
   "devDependencies": {
-    "jshint": "^2.5.6"
+    "6to5": "^1.15.0",
+    "JSONStream": "^0.10.0",
+    "body-parser": "^1.10.0",
+    "bunyan": "^1.2.3",
+    "express": "^4.10.6",
+    "immutable": "^3.4.1",
+    "js-csp": "^0.3.2",
+    "jshint": "^2.5.6",
+    "mocha": "^2.0.1",
+    "request": "^2.51.0",
+    "transducers.js": "^0.2.3",
+    "when": "^3.6.4"
   }
 }

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,12 @@
+# Test suite
+
+Currently this is a set of blackbox tests designed to operate against the public
+API of dutch-master (which is currently: signals in, log messages out).
+
+The tests set up a local HTTP server knows as the 'worker coordinator'. Then a
+cluster is started. The 'worker' that we ask dutch-master to start for us will
+immediately contact the worker coordinator to report that it has been started
+and await further instructions.
+
+With this arrangement we can drive a wide variety of failure scenarios by forcing
+workers to die, not start, hang, or not exit cleanly when requested.

--- a/test/restart.js
+++ b/test/restart.js
@@ -1,0 +1,168 @@
+var csp = require('js-csp')
+  , assert = require('assert')
+  , immutable = require('immutable')
+  , workerCoordinator = require('./support/worker-coordinator')
+  , helpers = require('./support/helpers')
+
+function* takeOrTimeout(ch, msg) {
+  var timeout = csp.timeout(1000)
+
+  var val = yield csp.alts([ch, timeout])
+  if (val.channel === timeout) {
+    throw new Error('Timed out while "' + msg + '"')
+  }
+
+  return val
+}
+
+function assertRestart(numWorkers) {
+  afterEach(function () {
+    process.kill(this.cluster.pid, 'SIGKILL')
+  })
+
+  context('with a long request in progress', function () {
+    beforeEach(function () {
+      this.longRequestCh = helpers.httpGetToChan('http://localhost:' + this.clusterPort + '/long-request')
+    })
+
+    describe('restart', function () {
+      beforeEach(function (done) {
+        csp.go(function* () {
+          var restartCompleteCh = helpers.waitForLogMessage('Restart complete', this.logMult)
+
+          this.workerSigtermChans = this.initialWorkerIds.map(id => {
+            return this.coordinator.requestToChan('post', '/worker/' + id + '/signal/SIGTERM')
+          })
+
+          process.kill(this.cluster.pid, 'SIGUSR2')
+
+          // Wait for replacement workers to come online
+          this.newWorkerIds = immutable.Set()
+          for (var i = 0; i < numWorkers; i++) {
+            this.newWorkerIds = this.newWorkerIds.add(yield csp.take(this.coordinator.workerActiveCh))
+          }
+
+          yield csp.take(this.coordinator.tellWorkers(this.newWorkerIds, 'startListening'))
+
+          yield csp.take(restartCompleteCh)
+          this.coordinator.tellWorkers(this.initialWorkerIds, 'completeLongRequest')
+          done()
+        }.bind(this))
+      })
+
+      it('should complete the long request successfully', function (done) {
+        csp.go(function* () {
+          var longReqResponse = yield csp.take(this.longRequestCh)
+          assert.equal(200, longReqResponse.get('status'))
+          done()
+        }.bind(this))
+      })
+
+      it('new requests should be handled by the new workers', function (done) {
+        csp.go(function* () {
+          var helloWorldResp = yield csp.take(helpers.httpGetToChan('http://localhost:' + this.clusterPort + '/'))
+          assert.equal(200, helloWorldResp.get('status'))
+          assert(
+            this.newWorkerIds.contains(helloWorldResp.getIn(['body', 'workerId']))
+          , 'Request was handled by an OLD worker'
+          )
+          done()
+        }.bind(this))
+      })
+
+      it('should send SIGTERM to the old workers', function (done) {
+        csp.go(function* () {
+          var merged = csp.operations.merge(this.workerSigtermChans.toArray())
+
+          for (var i = 0; i < this.workerSigtermChans.count(); i++) {
+            yield csp.take(merged)
+          }
+
+          done()
+        }.bind(this))
+      })
+    })
+  })
+}
+
+context('all workers running normally', function () {
+  var numWorkers = 2
+
+  beforeEach(function (done) {
+    csp.go(function* () {
+      this.coordinator = workerCoordinator()
+
+      this.cluster = helpers.startCluster({
+        COORDINATOR_PORT: yield csp.take(this.coordinator.portCh)
+      })
+
+      this.logMult = csp.operations.mult(this.cluster.stdoutCh)
+      this.clusterReadyCh = helpers.waitForLogMessage('Cluster ready', this.logMult)
+
+      done()
+    }.bind(this))
+  })
+
+  context('having started successfully', function () {
+    beforeEach(function (done) {
+      csp.go(function* () {
+        // Wait for workers to be started by the cluster
+        var workerIds = []
+        for (var i = 0; i < numWorkers; i++) {
+          workerIds.push(yield csp.take(this.coordinator.workerActiveCh))
+        }
+        this.initialWorkerIds = immutable.Set(workerIds)
+
+
+        // Tell workers to start listening
+        var listeningCh = this.coordinator.tellWorkers(this.initialWorkerIds, 'startListening')
+
+        // Grab the port that the cluster is listening on
+        this.clusterPort = (yield csp.take(listeningCh)).map(x => x.get('clusterPort')).first()
+
+        yield* takeOrTimeout(this.clusterReadyCh, 'Waiting for Cluster Ready log message')
+
+        done()
+      }.bind(this))
+    })
+
+    assertRestart(numWorkers)
+  })
+
+  context('after one worker fails to start one time', function() {
+    beforeEach(function(done) {
+      csp.go(function*() {
+        // Wait for workers to be started by the cluster
+        var workerIds = []
+        for (var i = 0; i < numWorkers; i++) {
+          workerIds.push(yield csp.take(this.coordinator.workerActiveCh))
+        }
+        this.initialWorkerIds = immutable.Set(workerIds)
+
+        // Tell one worker to crash
+        var badWorkerId = this.initialWorkerIds.first()
+        this.coordinator.tellWorker(badWorkerId, 'crash')
+
+        // Tell the other workers to start listening
+        var goodWorkerIds = this.initialWorkerIds.rest()
+        this.coordinator.tellWorkers(goodWorkerIds, 'startListening')
+
+        // Wait for another worker to come online
+        var replacementWorkerId = yield csp.take(this.coordinator.workerActiveCh)
+        this.initialWorkerIds = this.initialWorkerIds.add(replacementWorkerId).delete(badWorkerId)
+
+        // Tell that worker to start listening
+        var listeningCh = this.coordinator.tellWorker(replacementWorkerId, 'startListening')
+
+        // Grab the port that the cluster is listening on
+        this.clusterPort = (yield csp.take(listeningCh)).map(x => x.get('clusterPort')).first()
+
+        yield* takeOrTimeout(this.clusterReadyCh, 'Waiting for Cluster Ready log message')
+
+        done()
+      }.bind(this))
+    })
+
+    assertRestart(numWorkers)
+  })
+})

--- a/test/support/6to5.js
+++ b/test/support/6to5.js
@@ -1,0 +1,4 @@
+require('6to5/register')({
+  ignore: false,
+  only: /test\/|node_modules\/js-csp/
+})

--- a/test/support/helpers.js
+++ b/test/support/helpers.js
@@ -1,0 +1,54 @@
+var request = require('request')
+  , csp = require('js-csp')
+  , transducers = require('transducers.js')
+  , spawn = require('child_process').spawn
+  , JSONStream = require('JSONStream')
+  , immutable = require('immutable')
+  , filter = transducers.filter
+  , tap = csp.operations.mult.tap
+
+// Initiate an HTTP GET request to the specified URL. Returns a channel that
+// will have a map placed on it containing the response status and body
+module.exports.httpGetToChan = function (url) {
+  var ch = csp.chan()
+
+  request.get(url, {json: {}}, (err, res, body) => {
+    if (err) {
+      return csp.putAsync(ch, immutable.fromJS({err: err}))
+    }
+
+    csp.putAsync(ch, immutable.fromJS({status: res.statusCode, body: body}))
+  })
+
+  return ch
+}
+
+// Returns a channel that will receive log messages from the specified mult
+// (which issues JSON log entries) matching the specified message.
+module.exports.waitForLogMessage = function (message, mult) {
+  return tap(mult, csp.chan(1, filter(x => x.msg === message)))
+}
+
+// Start the dutch-master module. Returns a map containing the PID of the master
+// process, and a channel that will have log messages from the cluster placed
+// upon it in JSON format (obtained by piping the masters STDOUT into a streaming
+// JSON parser).
+module.exports.startCluster = function (env) {
+  var nodeCmd = process.execPath
+    , args = [__dirname + '/master-shim.js']
+    , stdoutCh = csp.chan()
+
+  var ps = spawn(nodeCmd, args, {
+    env: env
+  , stdio: [null, 'pipe', process.stderr]
+  })
+
+  ps.stdout
+  .pipe(JSONStream.parse())
+  .on('data', data => csp.putAsync(stdoutCh, data))
+
+  return {
+    stdoutCh: stdoutCh
+  , pid: ps.pid
+  }
+}

--- a/test/support/master-shim.js
+++ b/test/support/master-shim.js
@@ -1,0 +1,11 @@
+// Shim for running dutch-master so it can be run out of process and shut down
+// without killing the test process
+
+require('../../')({
+  worker: __dirname + '/worker.js',
+  numWorkers: 2,
+  logger: require('bunyan').createLogger({
+    name: 'shim'
+  }),
+  workerEnvironment: process.env
+})

--- a/test/support/worker-coordinator.js
+++ b/test/support/worker-coordinator.js
@@ -1,0 +1,111 @@
+var csp = require('js-csp')
+  , immutable = require('immutable')
+  , crypto = require('crypto')
+
+module.exports = function () {
+  var app = require('express')()
+    , server = require('http').createServer(app)
+    , instructionChMap = immutable.Map()
+    , workerActiveCh = csp.chan()
+    , portCh = csp.chan()
+
+  app.use(require('body-parser').json())
+
+  app.use((req, res, next) => {
+    req.body = immutable.fromJS(req.body)
+    next()
+  })
+
+  app.param('id', (req, res, next, id) => {
+    req.params.id = Number(id)
+    next()
+  })
+
+  // Called by a worker once it has started.
+  app.post('/worker/:id/running', (req, res) => {
+    instructionChMap = instructionChMap.set(req.params.id, csp.chan())
+    csp.putAsync(workerActiveCh, req.params.id)
+    res.end()
+  })
+
+  // Called by a worker to receive instructions on what to do. Long-polls
+  // until an action is available.
+  app.get('/worker/:id', (req, res) => {
+    var instructionCh = instructionChMap.get(req.params.id)
+
+    csp.go(function* () {
+      res.json(yield csp.take(instructionCh))
+    })
+  })
+
+  function requestToChan(method, path) {
+    var ch = csp.chan()
+
+    app[method](path, (req, res) => {
+      csp.putAsync(ch, req.body)
+      ch.close()
+      res.end()
+    })
+
+    return ch
+  }
+
+  server.listen(null, () => {
+    csp.putAsync(portCh, server.address().port)
+  })
+
+  // Given an immutable Map<key:chan> wait for each chan to complete
+  // then return a new Map<key:value>
+  function mapChan(obj) {
+    return csp.go(function* () {
+      var result = {}
+        , jsObj = obj.toObject()
+
+      for (var key in jsObj) {
+        result[key] = yield csp.take(jsObj[key])
+      }
+
+      return immutable.Map(result)
+    })
+  }
+
+  // Issues an instruction to the specified worker ids, returns a channel that
+  // will have a map placed on it containing the response from each worker
+  function tellWorkers(workerIds, action) {
+    var chs = instructionChMap
+    .filter((ch, workerId) => workerIds.contains(workerId))
+    .map((ch, workerId) => {
+      return csp.go(function* () {
+        var instructionId = crypto.randomBytes(16).toString('hex')
+          , completionUrl = '/instruction/' + instructionId + '/complete'
+          , completeCh = requestToChan('post', completionUrl)
+
+        yield csp.put(ch, {action: action, completionUrl: completionUrl})
+
+        return yield csp.take(completeCh)
+      })
+    })
+
+    return mapChan(chs)
+  }
+
+  // Issues an instruction to the specified worker id, returns a channel that
+  // will have a map placed on it containing the response from the worker
+  function tellWorker(workerId, action) {
+    return tellWorkers(immutable.fromJS([workerId]), action)
+  }
+
+  return {
+    // Channel that will have the port number of this coordinator placed
+    // on it once it starts listening
+    portCh: portCh
+
+    // Channel that has a workerId placed on it each time a new worker
+    // becomes active
+  , workerActiveCh: workerActiveCh
+
+  , tellWorkers: tellWorkers
+  , tellWorker: tellWorker
+  , requestToChan: requestToChan
+  }
+}

--- a/test/support/worker.js
+++ b/test/support/worker.js
@@ -1,0 +1,82 @@
+// This fake worker gets invoked by dutch-master, and performs actions we tell
+// it to via communications with the worker-coordinator.
+
+// This is not run through the 6to5 compiler so no ES6 syntax is available.
+
+// All stdout output from the master process (and hence, this script) will be
+// parsed by a streaming JSON parser to interpret log output. If you need to add
+// logging in here for diagnostic purposes, use `console.error`.
+
+var request = require('request')
+  , when = require('when')
+  , cluster = require('cluster')
+  , immutable = require('immutable')
+
+var app = require('express')()
+  , server = require('http').createServer(app)
+  , coordinatorUrl = 'http://localhost:' + process.env.COORDINATOR_PORT
+  , workerInfoUrl = coordinatorUrl + '/worker/' + cluster.worker.id
+  , sharedState = immutable.Map()
+
+function ensureLongReqState() {
+  if (!sharedState.has('longRequestDefer')) {
+    sharedState = sharedState.set('longRequestDefer', when.defer())
+  }
+
+  return sharedState.get('longRequestDefer')
+}
+
+process.on('SIGTERM', function () {
+  request.post(workerInfoUrl + '/signal/SIGTERM', {json: {}}, function () {
+    process.exit(143)
+  })
+})
+
+// Simple happy-path endpoint
+app.get('/', function (req, res) {
+  res.json({workerId: cluster.worker.id})
+})
+
+// This endpoint will not complete until we receive an instruction to do so
+app.get('/long-request', function (req, res) {
+  ensureLongReqState().promise.done(function () {
+    sharedState = sharedState.delete('longRequestDefer')
+    res.json({
+      workerId: cluster.worker.id
+    })
+  })
+})
+
+// Notify the coordinator that we are running
+request.post(workerInfoUrl + '/running', waitForInstruction)
+
+// Long-poll for instructions
+function waitForInstruction() {
+  request.get(workerInfoUrl, {json: {}}, function (err, res, body) {
+    if (err) return
+
+    if (body.action === 'startListening' && !sharedState.get('listening')) {
+      sharedState = sharedState.set('listening', true)
+
+      server.listen(null, function () {
+        request.post(coordinatorUrl + body.completionUrl, {
+          json: {
+            clusterPort: server.address().port
+          }
+        })
+      })
+    }
+
+    if (body.action === 'completeLongRequest') {
+      request.post(coordinatorUrl + body.completionUrl)
+      ensureLongReqState().resolve()
+    }
+
+    if (body.action === 'crash') {
+      request.post(coordinatorUrl + body.completionUrl)
+      process.exit(1)
+    }
+
+    waitForInstruction()
+  })
+}


### PR DESCRIPTION
This is a happy-path black box test. It starts a 2-worker cluster, then requests a restart. It asserts that a long-running request initiated before the restart completes successfully after the new workers are available, a request issued after the restart is handled by the new workers, and that the old workers get a SIGTERM signal.

To achieve this, we use a custom worker script that, once listening, 'phones home' to a very small Express app that is set up by the test, so the workers can report on their status and be instructed to perform certain actions. With this in place we can drive out many different scenarios of worker behavior.

The tests are built using [js-csp](https://github.com/ubolonton/js-csp) and ES6 (compiled during testing) for the most expressive way to represent the complex asynchronous interactions.

@mdimas @quaelin 