### PR TITLE
Properly stop workers during shutdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,10 @@ module.exports = function (options) {
 
     restarting = true
 
+    _.each(workers, function (worker) {
+      worker.state = 'stopping'
+    })
+
     var timeout = setTimeout(function () {
       logger.warn('Cluster did not shutdown cleanly within timeout, exiting')
       process.exit(1)

--- a/index.js
+++ b/index.js
@@ -47,12 +47,13 @@ module.exports = function (options) {
 
     _.each(workers, function (worker) {
       worker.state = 'stopping'
+      stopWorker(worker)
     })
 
     var timeout = setTimeout(function () {
       logger.warn('Cluster did not shutdown cleanly within timeout, exiting')
       process.exit(1)
-    }, 30000)
+    }, 10000)
 
     cluster.disconnect(function () {
       restarting = false
@@ -182,7 +183,7 @@ module.exports = function (options) {
         } catch (err) {
           metaWorker.logger.debug(err, 'Could not kill with worker.process.kill()')
         }
-      }, 30000)
+      }, 5000)
     }
 
     switch (metaWorker.state) {


### PR DESCRIPTION
Explicitly stop workers when shutting down, since `cluster.disconnect` does not handle workers that do not close cleanly.

Reduce timeouts, making sure the individual worker timeout is much shorter than the cluster shutdown timeout, so the cluster won't be killed before the workers have been cleaned up.

@brian-hall @quaelin 