### PR TITLE
Fix shutdown condition where children are orphaned

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,12 +52,8 @@ module.exports = function (options) {
       process.exit(1)
     }, 10000)
 
-    var workersAllExited= function() {
-      return _.every(workers, {state: 'exited'})
-    }
-
     var cleanExit = function () {
-      if (workersAllExited()) {
+      if (_.every(workers, {state: 'exited'})) {
         restarting = false
         clearTimeout(timeout)
         logger.info('Cluster shutdown cleanly')

--- a/index.js
+++ b/index.js
@@ -52,17 +52,12 @@ module.exports = function (options) {
       process.exit(1)
     }, 10000)
 
+    var workersAllExited= function() {
+      return _.every(workers, {state: 'exited'})
+    }
+
     var cleanExit = function () {
-      var workersDone = true
-
-      _.each(workers, function (worker) {
-        if (worker.state !== 'exited') {
-          workersDone = false
-          return
-        }
-      })
-
-      if (workersDone) {
+      if (workersAllExited()) {
         restarting = false
         clearTimeout(timeout)
         logger.info('Cluster shutdown cleanly')


### PR DESCRIPTION
There were cases in the previous implementation where the master would exit before the children were properly cleaned up.

This implementation forces the master to look at the state of its workers before exiting.